### PR TITLE
Validate worker workspace boundaries

### DIFF
--- a/agents.toml.example
+++ b/agents.toml.example
@@ -12,6 +12,12 @@
 # [server]
 # idle_exit_sec = 7200
 
+# Optional dispatch-time workspace validation. Empty allowed_roots (the
+# default) allows any existing absolute directory; this is not a sandbox.
+# [workspace]
+# allowed_roots = ["D:/code"]
+# reject_reparse = true
+
 # Dispatch policy: mode = manual | auto | eager (default auto).
 # instructions is free text the coordinator reads via list_agents; it
 # overrides the default worker split and persists across sessions.

--- a/src/agent_bridge/adapters/acp.py
+++ b/src/agent_bridge/adapters/acp.py
@@ -400,7 +400,9 @@ class AcpAdapter(Adapter):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
-            cwd=self.agent.cwd or session.cwd or None,
+            # Registry rejects a configured cwd that differs from the session.
+            # Keep the OS process and ACP session on that exact validated cwd.
+            cwd=session.cwd,
             limit=STDIO_LIMIT,
             **kwargs,
         )

--- a/src/agent_bridge/adapters/antigravity.py
+++ b/src/agent_bridge/adapters/antigravity.py
@@ -236,7 +236,7 @@ class AgyAdapter(Adapter):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
-            cwd=task.cwd or session.cwd,
+            cwd=session.cwd,
             limit=STDIO_LIMIT,
             **kwargs,
         )

--- a/src/agent_bridge/config.py
+++ b/src/agent_bridge/config.py
@@ -78,6 +78,16 @@ class ServerConfig(BaseModel):
     idle_exit_sec: int = 7200
 
 
+class WorkspacePolicy(BaseModel):
+    """Dispatch-time workspace validation configuration.
+
+    Empty ``allowed_roots`` retains the historical unrestricted-root behavior.
+    """
+
+    allowed_roots: list[str] = Field(default_factory=list)
+    reject_reparse: bool = True
+
+
 COORDINATOR_MODES = ("manual", "auto", "eager")
 # The notes that inspired this used safe/yolo; yolo already means
 # "auto-approve tool calls" for Kimi and Grok, so the canonical names differ.
@@ -128,6 +138,7 @@ class AppConfig(BaseModel):
     agents: dict[str, AgentConfig] = Field(default_factory=dict)
     env: EnvConfig = Field(default_factory=EnvConfig)
     server: ServerConfig = Field(default_factory=ServerConfig)
+    workspace: WorkspacePolicy = Field(default_factory=WorkspacePolicy)
     coordinator: CoordinatorConfig = Field(default_factory=CoordinatorConfig)
 
     def get(self, name: str) -> AgentConfig:
@@ -207,6 +218,18 @@ def _coerce_server(raw: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _coerce_workspace(raw: dict[str, Any]) -> dict[str, Any]:
+    block = raw.get("workspace")
+    if not isinstance(block, dict):
+        return {}
+    out: dict[str, Any] = {}
+    if block.get("allowed_roots") is not None:
+        out["allowed_roots"] = [str(item) for item in block["allowed_roots"]]
+    if block.get("reject_reparse") is not None:
+        out["reject_reparse"] = bool(block["reject_reparse"])
+    return out
+
+
 def _coerce_coordinator(raw: dict[str, Any]) -> dict[str, Any]:
     block = raw.get("coordinator")
     if not isinstance(block, dict):
@@ -277,6 +300,12 @@ def _merge_server(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, An
     return out
 
 
+def _merge_workspace(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    out.update(overlay)
+    return out
+
+
 def load_config(home: Path | None = None) -> AppConfig:
     bundled_raw = _load_toml(bundled_agents_toml())
     user_home = home or bridge_home()
@@ -302,6 +331,9 @@ def load_config(home: Path | None = None) -> AppConfig:
     server = ServerConfig.model_validate(
         _merge_server(_coerce_server(bundled_raw), _coerce_server(overlay_raw))
     )
+    workspace = WorkspacePolicy.model_validate(
+        _merge_workspace(_coerce_workspace(bundled_raw), _coerce_workspace(overlay_raw))
+    )
     coord_raw = {**_coerce_coordinator(bundled_raw), **_coerce_coordinator(overlay_raw)}
     # Per-host override: each MCP host entry can set its own mode via env
     # (e.g. Codex manual, Cursor eager) without a second config file.
@@ -310,4 +342,10 @@ def load_config(home: Path | None = None) -> AppConfig:
         coord_raw["mode"] = env_mode
     coord_raw["mode"] = normalize_coordinator_mode(coord_raw.get("mode"))
     coordinator = CoordinatorConfig.model_validate(coord_raw)
-    return AppConfig(agents=agents, env=env, server=server, coordinator=coordinator)
+    return AppConfig(
+        agents=agents,
+        env=env,
+        server=server,
+        workspace=workspace,
+        coordinator=coordinator,
+    )

--- a/src/agent_bridge/registry.py
+++ b/src/agent_bridge/registry.py
@@ -37,6 +37,7 @@ from agent_bridge.processes import count_sibling_servers, owner_alive, process_c
 from agent_bridge.transcript import page_events, read_events, read_events_tail, recent_activity
 from agent_bridge.worker_env import describe_env, install_host_env, is_worker_context
 from agent_bridge.workspace import merge_files_changed, snapshot_workspace
+from agent_bridge.workspace_policy import WorkspacePolicy as WorkspaceValidator
 
 log = logging.getLogger(__name__)
 
@@ -366,11 +367,11 @@ class Registry:
                 "asked for a worker on this task. If they did, retry with "
                 "user_requested=true; otherwise do the work yourself."
             )
-        cwd_path = Path(cwd)
-        if not cwd_path.is_absolute():
-            raise ValueError("cwd must be an absolute path")
+        workspace_policy = WorkspaceValidator.model_validate(self.config.workspace.model_dump())
+        cwd_path = workspace_policy.validate_cwd(cwd)
         effort = normalize_effort(effort)
         cfg = self.config.get(agent)
+        workspace_policy.validate_configured_cwd(cfg.cwd, cwd_path)
         async with self._lock:
             if session_id:
                 session = self.sessions.get(session_id)
@@ -378,7 +379,7 @@ class Registry:
                     raise KeyError(f"unknown session {session_id}")
                 if session.agent != agent:
                     raise ValueError(f"session {session_id} belongs to agent {session.agent}, not {agent}")
-                if Path(session.cwd).resolve() != cwd_path.resolve():
+                if session.cwd != str(cwd_path):
                     raise ValueError(
                         f"session {session.session_id} is bound to {session.cwd}; "
                         "follow-up cwd must be the same project folder"
@@ -392,7 +393,7 @@ class Registry:
                 session = Session(
                     session_id=_new_id("sess"),
                     agent=agent,
-                    cwd=str(cwd_path.resolve()),
+                    cwd=str(cwd_path),
                     model=model,
                     effort=effort,
                     title=title,
@@ -407,7 +408,7 @@ class Registry:
             if title:
                 session.title = title
             if session_id is None:
-                session.cwd = str(cwd_path.resolve())
+                session.cwd = str(cwd_path)
             session.last_active_at = iso()
             task = Task(
                 task_id=_new_id("task"),

--- a/src/agent_bridge/workspace_policy.py
+++ b/src/agent_bridge/workspace_policy.py
@@ -1,0 +1,94 @@
+"""Validation for a worker workspace before it reaches a process spawn.
+
+This is an input policy, not a filesystem sandbox.  It makes the workspace
+identity explicit and rejects paths whose component traversal is ambiguous.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+
+class WorkspacePolicyError(ValueError):
+    """Raised when a requested worker workspace is unsafe or out of policy."""
+
+
+class WorkspacePolicy(BaseModel):
+    """Validate dispatch workspaces against optional local configuration."""
+
+    allowed_roots: list[str] = Field(default_factory=list)
+    reject_reparse: bool = True
+
+    def validate_cwd(self, cwd: str | Path) -> Path:
+        """Return a normalized existing directory or fail closed."""
+        raw = str(cwd)
+        path = Path(raw)
+        if not path.is_absolute():
+            raise WorkspacePolicyError("cwd must be an absolute path")
+        if not path.exists():
+            raise WorkspacePolicyError(f"cwd does not exist: {path}")
+        if not path.is_dir():
+            raise WorkspacePolicyError(f"cwd is not a directory: {path}")
+        if self.reject_reparse:
+            _reject_reparse_components(path, label="cwd")
+        normalized = path.resolve(strict=True)
+        for root in self.allowed_roots:
+            allowed = self._validate_root(root)
+            try:
+                normalized.relative_to(allowed)
+            except ValueError:
+                continue
+            break
+        else:
+            if self.allowed_roots:
+                roots = ", ".join(self.allowed_roots)
+                raise WorkspacePolicyError(f"cwd is outside configured allowed_roots: {roots}")
+        return normalized
+
+    def validate_configured_cwd(self, configured_cwd: str | None, session_cwd: Path) -> None:
+        """Ensure an optional per-agent cwd cannot override the session cwd."""
+        if not configured_cwd:
+            return
+        configured = self.validate_cwd(configured_cwd)
+        if _normalized_compare(configured) != _normalized_compare(session_cwd):
+            raise WorkspacePolicyError(
+                f"configured agent cwd {configured} must equal session cwd {session_cwd}"
+            )
+
+    def _validate_root(self, raw: str) -> Path:
+        root = Path(raw)
+        if not root.is_absolute():
+            raise WorkspacePolicyError(f"allowed root must be an absolute path: {root}")
+        if not root.exists() or not root.is_dir():
+            raise WorkspacePolicyError(f"allowed root is not an existing directory: {root}")
+        if self.reject_reparse:
+            _reject_reparse_components(root, label="allowed root")
+        return root.resolve(strict=True)
+
+
+def _normalized_compare(path: Path) -> str:
+    return os.path.normcase(os.path.normpath(str(path.resolve(strict=True))))
+
+
+def _reject_reparse_components(path: Path, *, label: str) -> None:
+    """Reject every symlink or Windows reparse point in a lexical path walk."""
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            continue
+        current /= part
+        try:
+            info = current.lstat()
+        except OSError as exc:
+            raise WorkspacePolicyError(f"{label} component is not accessible: {current}") from exc
+        attrs = getattr(info, "st_file_attributes", 0)
+        reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x0400)
+        if current.is_symlink() or attrs & reparse_flag:
+            raise WorkspacePolicyError(f"{label} contains a symlink or reparse point: {current}")

--- a/tests/test_acp_paths.py
+++ b/tests/test_acp_paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -50,3 +51,36 @@ async def test_rpc_timeout_raises_clear_error(tmp_path):
     session = Session(session_id="sess_rpc", agent="cursor", cwd=str(tmp_path))
     with pytest.raises(RpcTimeoutError, match="session/new timed out"):
         await adapter._rpc(asyncio.sleep(30), "session/new", session, timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_spawn_uses_session_cwd_not_agent_override(tmp_path, monkeypatch):
+    configured = tmp_path / "configured"
+    configured.mkdir()
+    requested = tmp_path / "requested"
+    requested.mkdir()
+    adapter = AcpAdapter(
+        AgentConfig(
+            name="cursor", protocol="acp", command=["cursor-agent"], cwd=str(configured)
+        ),
+        tmp_path,
+    )
+    session = Session(session_id="sess_cwd", agent="cursor", cwd=str(requested))
+    seen: dict[str, str] = {}
+
+    async def fake_spawn(*args, **kwargs):
+        seen["cwd"] = kwargs["cwd"]
+        return SimpleNamespace(stdin=object(), stdout=object(), stderr=None, pid=None)
+
+    async def no_rpc(*args, **kwargs):
+        return None
+
+    class Connection:
+        def initialize(self, **kwargs):
+            return None
+
+    monkeypatch.setattr("agent_bridge.adapters.acp.asyncio.create_subprocess_exec", fake_spawn)
+    monkeypatch.setattr("agent_bridge.adapters.acp.connect_to_agent", lambda *args: Connection())
+    monkeypatch.setattr(adapter, "_rpc", no_rpc)
+    await adapter._spawn(session)
+    assert seen["cwd"] == str(requested)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,6 +116,23 @@ idle_exit_sec = 0
     assert cfg.server.idle_exit_sec == 0
 
 
+def test_workspace_policy_defaults_and_overlay(tmp_path):
+    assert AppConfig().workspace.allowed_roots == []
+    assert AppConfig().workspace.reject_reparse is True
+    root = tmp_path / "root"
+    root.mkdir()
+    (tmp_path / "agents.toml").write_text(
+        f'''[workspace]
+allowed_roots = ["{root.as_posix()}"]
+reject_reparse = false
+''',
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.workspace.allowed_roots == [root.as_posix()]
+    assert cfg.workspace.reject_reparse is False
+
+
 def test_coordinator_defaults(tmp_path, monkeypatch):
     monkeypatch.delenv("AGENT_BRIDGE_MODE", raising=False)
     cfg = load_config(tmp_path)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from agent_bridge.adapters.fake import FakeAdapter
+from agent_bridge.config import AgentConfig, AppConfig, WorkspacePolicy
 from agent_bridge.models import ProcState, Session, Task, TaskStatus, TurnResult, iso
 from agent_bridge.paths import state_path
 from agent_bridge.persist import atomic_write_json, read_json
@@ -112,6 +113,47 @@ async def test_relative_cwd_rejected(bridge_home):
     try:
         with pytest.raises(ValueError, match="absolute"):
             await registry.dispatch_task("fake", "x", cwd="relative")
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_workspace_outside_configured_root(bridge_home, tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    config = AppConfig(
+        agents={"fake": AgentConfig(name="fake", protocol="fake", command=["fake"])},
+        workspace=WorkspacePolicy(allowed_roots=[str(allowed)]),
+    )
+    registry = Registry.create(bridge_home, config=config)
+    await registry.start()
+    try:
+        with pytest.raises(ValueError, match="outside configured allowed_roots"):
+            await registry.dispatch_task("fake", "x", cwd=str(outside))
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_agent_cwd_that_differs_from_session(bridge_home, tmp_path):
+    configured = tmp_path / "configured"
+    configured.mkdir()
+    requested = tmp_path / "requested"
+    requested.mkdir()
+    config = AppConfig(
+        agents={
+            "fake": AgentConfig(
+                name="fake", protocol="fake", command=["fake"], cwd=str(configured)
+            )
+        }
+    )
+    registry = Registry.create(bridge_home, config=config)
+    await registry.start()
+    try:
+        with pytest.raises(ValueError, match="must equal session cwd"):
+            await registry.dispatch_task("fake", "x", cwd=str(requested))
     finally:
         await registry.stop()
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 
+import pytest
+
 from agent_bridge.workspace import (
     collect_update_paths,
     merge_files_changed,
     snapshot_workspace,
 )
+from agent_bridge.workspace_policy import WorkspacePolicy, WorkspacePolicyError
 
 
 def test_snapshot_sees_new_file_and_ignores_sessions(tmp_path: Path):
@@ -46,3 +49,66 @@ def test_collect_nested_tool_paths():
     )
     assert "README.md" in found
     assert "src/main.py" in found
+
+
+def test_workspace_policy_rejects_missing_relative_and_file(tmp_path: Path):
+    policy = WorkspacePolicy()
+    with pytest.raises(WorkspacePolicyError, match="absolute"):
+        policy.validate_cwd("relative")
+    with pytest.raises(WorkspacePolicyError, match="does not exist"):
+        policy.validate_cwd(tmp_path / "missing")
+    file = tmp_path / "file.txt"
+    file.write_text("x", encoding="utf-8")
+    with pytest.raises(WorkspacePolicyError, match="not a directory"):
+        policy.validate_cwd(file)
+
+
+def test_workspace_policy_rejects_cwd_outside_allowed_root(tmp_path: Path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    policy = WorkspacePolicy(allowed_roots=[str(allowed)])
+    assert policy.validate_cwd(allowed) == allowed.resolve()
+    with pytest.raises(WorkspacePolicyError, match="outside configured allowed_roots"):
+        policy.validate_cwd(outside)
+
+
+def test_workspace_policy_rejects_symlink_component(tmp_path: Path):
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+    with pytest.raises(WorkspacePolicyError, match="symlink or reparse"):
+        WorkspacePolicy().validate_cwd(link)
+
+
+def test_workspace_policy_rejects_windows_reparse_attribute(tmp_path: Path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    original_lstat = Path.lstat
+
+    class ReparseStat:
+        st_file_attributes = 0x0400
+        st_mode = 0
+
+    def reparse_lstat(path: Path):
+        if path == workspace:
+            return ReparseStat()
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", reparse_lstat)
+    with pytest.raises(WorkspacePolicyError, match="symlink or reparse"):
+        WorkspacePolicy().validate_cwd(workspace)
+
+
+def test_workspace_policy_requires_configured_cwd_to_match_session(tmp_path: Path):
+    first = tmp_path / "first"
+    first.mkdir()
+    second = tmp_path / "second"
+    second.mkdir()
+    with pytest.raises(WorkspacePolicyError, match="must equal session cwd"):
+        WorkspacePolicy().validate_configured_cwd(str(first), second)


### PR DESCRIPTION
Adds generic workspace policy validation for absolute existing directories, optional allowed roots, symlink and Windows reparse-point rejection, and configured-versus-session cwd consistency before worker launch. Tests: uv run --extra dev python -B -m pytest -q (220 passed, 1 skipped where Windows symlink privilege was unavailable; reparse behavior has focused coverage).