### PR TITLE
Validate worker cwd before dispatch

### DIFF
--- a/src/agent_bridge/registry.py
+++ b/src/agent_bridge/registry.py
@@ -369,6 +369,10 @@ class Registry:
         cwd_path = Path(cwd)
         if not cwd_path.is_absolute():
             raise ValueError("cwd must be an absolute path")
+        if not cwd_path.exists():
+            raise ValueError(f"cwd does not exist: {cwd_path}")
+        if not cwd_path.is_dir():
+            raise ValueError(f"cwd is not a directory: {cwd_path}")
         effort = normalize_effort(effort)
         cfg = self.config.get(agent)
         async with self._lock:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -117,6 +117,23 @@ async def test_relative_cwd_rejected(bridge_home):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_rejects_missing_cwd_and_file_path(bridge_home, tmp_path):
+    registry = Registry.create(bridge_home)
+    await registry.start()
+    try:
+        with pytest.raises(ValueError, match="does not exist"):
+            await registry.dispatch_task("fake", "x", cwd=str(tmp_path / "missing"))
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("x", encoding="utf-8")
+        with pytest.raises(ValueError, match="directory"):
+            await registry.dispatch_task("fake", "x", cwd=str(file_path))
+        assert registry.sessions == {}
+        assert registry.tasks == {}
+    finally:
+        await registry.stop()
+
+
+@pytest.mark.asyncio
 async def test_bridge_restart_marks_running_failed(bridge_home):
     atomic_write_json(
         state_path(bridge_home),


### PR DESCRIPTION
## Summary
- reject dispatches whose `cwd` does not exist or is not a directory
- include the rejected path in the validation error
- keep invalid dispatches from creating session or task state

This is intentionally limited to the existing-directory check discussed in #3. It does not add allowed roots, symlink/reparse restrictions, sandbox claims, or changes to `AgentConfig.cwd` behavior.

## Tests
- `pytest tests/test_registry.py -q`: 32 passed
- full test suite: 258 passed