### PR TITLE
Fix transcript tail and pagination boundaries

### DIFF
--- a/src/agent_bridge/transcript.py
+++ b/src/agent_bridge/transcript.py
@@ -54,12 +54,16 @@ def read_events_tail(
         return []
     size = path.stat().st_size
     with path.open("rb") as fh:
+        discard_first_line = False
         if size > max_bytes:
-            fh.seek(size - max_bytes)
+            start = size - max_bytes
+            fh.seek(start - 1)
+            discard_first_line = fh.read(1) != b"\n"
+            fh.seek(start)
         blob = fh.read()
     lines = blob.decode("utf-8", errors="replace").splitlines()
-    if size > max_bytes and lines:
-        lines = lines[1:]  # the first line is almost certainly cut mid-record
+    if discard_first_line and lines:
+        lines = lines[1:]  # the first line is cut mid-record
     events: list[dict[str, Any]] = []
     for line in lines:
         line = line.strip()
@@ -79,6 +83,10 @@ def page_events(
     kinds: Iterable[str] | None = None,
     max_bytes: int = PAGE_BYTE_BUDGET,
 ) -> dict[str, Any]:
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
     kind_set = set(kinds) if kinds else None
     selected = events
     if kind_set:

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,3 +1,8 @@
+import json
+
+import pytest
+
+from agent_bridge.paths import transcript_path
 from agent_bridge.transcript import append_event, page_events, read_events, read_events_tail
 
 
@@ -37,3 +42,25 @@ def test_read_events_tail_small_file_reads_everything(bridge_home):
     append_event("sess_s", "message_chunk", {"text": "only"}, bridge_home)
     assert read_events_tail("sess_s", bridge_home) == read_events("sess_s", bridge_home)
     assert read_events_tail("sess_missing", bridge_home) == []
+
+
+@pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+def test_read_events_tail_keeps_event_at_exact_line_boundary(bridge_home, line_ending):
+    first = {"type": "message_chunk", "data": {"text": "before"}}
+    last = {"type": "message_chunk", "data": {"text": "\u4e2d\u6587"}}
+    first_line = json.dumps(first, ensure_ascii=False).encode("utf-8") + line_ending
+    last_line = json.dumps(last, ensure_ascii=False).encode("utf-8") + line_ending
+    path = transcript_path("sess_boundary", bridge_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(first_line + last_line)
+
+    assert read_events_tail("sess_boundary", bridge_home, max_bytes=len(last_line)) == [last]
+
+
+def test_page_events_rejects_invalid_paging_parameters():
+    events = [{"type": "message_chunk"}]
+
+    with pytest.raises(ValueError, match="offset"):
+        page_events(events, offset=-1)
+    with pytest.raises(ValueError, match="limit"):
+        page_events(events, limit=0)


### PR DESCRIPTION
## Summary

- keep the first complete tail event when the byte window starts exactly at a JSONL record boundary
- reject negative offsets and non-positive limits
- preserve the existing transcript schema and normal pagination behavior

## Tests

- `pytest tests/test_transcript.py tests/test_server_tools.py -q` (9 passed)
- `pytest -q` (260 passed)