### PR TITLE
Keep logging setup retries idempotent

### DIFF
--- a/src/agent_bridge/logging_setup.py
+++ b/src/agent_bridge/logging_setup.py
@@ -12,12 +12,12 @@ def setup_logging(home: Path | None = None) -> None:
     root = logging.getLogger()
     if getattr(root, "_agent_bridge_configured", False):
         return
-    root.setLevel(logging.INFO)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
     stderr = logging.StreamHandler(sys.stderr)
     stderr.setFormatter(formatter)
-    root.addHandler(stderr)
     file_handler = RotatingFileHandler(log_path(home), maxBytes=2_000_000, backupCount=3, encoding="utf-8")
     file_handler.setFormatter(formatter)
+    root.setLevel(logging.INFO)
+    root.addHandler(stderr)
     root.addHandler(file_handler)
     root._agent_bridge_configured = True  # type: ignore[attr-defined]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from agent_bridge import logging_setup
+
+
+def test_setup_logging_retries_without_partial_configuration(monkeypatch, tmp_path: Path):
+    logger = logging.Logger("agent-bridge-test-logging")
+    logger.setLevel(logging.WARNING)
+    file_handler_calls = 0
+
+    class TestFileHandler(logging.Handler):
+        def __init__(self, filename: Path):
+            super().__init__()
+            self.filename = filename
+
+    def create_file_handler(filename, **_kwargs):
+        nonlocal file_handler_calls
+        file_handler_calls += 1
+        if file_handler_calls == 1:
+            raise OSError("simulated file handler initialization failure")
+        return TestFileHandler(filename)
+
+    monkeypatch.setattr(logging_setup.logging, "getLogger", lambda: logger)
+    monkeypatch.setattr(logging_setup, "RotatingFileHandler", create_file_handler)
+    monkeypatch.setattr(logging_setup, "log_path", lambda home: tmp_path / "bridge.log")
+
+    try:
+        try:
+            logging_setup.setup_logging(tmp_path)
+        except OSError as exc:
+            assert str(exc) == "simulated file handler initialization failure"
+        else:
+            raise AssertionError("expected file handler initialization to fail")
+
+        assert logger.handlers == []
+        assert logger.level == logging.WARNING
+        assert not getattr(logger, "_agent_bridge_configured", False)
+
+        logging_setup.setup_logging(tmp_path)
+        handlers = list(logger.handlers)
+
+        assert len(handlers) == 2
+        assert logger.level == logging.INFO
+        assert getattr(logger, "_agent_bridge_configured", False)
+        assert isinstance(handlers[0], logging.StreamHandler)
+        assert isinstance(handlers[1], TestFileHandler)
+        assert all(handler.formatter is not None for handler in handlers)
+        assert all(handler.formatter._fmt == "%(asctime)s %(levelname)s %(name)s: %(message)s" for handler in handlers)
+
+        logging_setup.setup_logging(tmp_path)
+
+        assert logger.handlers == handlers
+        assert file_handler_calls == 2
+    finally:
+        for handler in logger.handlers:
+            handler.close()


### PR DESCRIPTION
## Summary

- construct both logging handlers before mutating the root logger
- leave logger level, handlers, and the configured marker unchanged when file-handler initialization fails
- make a successful retry add one stderr/file pair while later calls remain no-ops

## Tests

- `pytest tests/test_logging_setup.py tests/test_cli.py tests/test_server_tools.py -q` (16 passed)
- `pytest -q` (258 passed)