### PR TITLE
安装协调器 Skill 时保留原始字节

### DIFF
--- a/src/agent_bridge/cli.py
+++ b/src/agent_bridge/cli.py
@@ -127,13 +127,13 @@ def install_skill(*, home: Path | None = None, only_existing: bool = False) -> l
     source = bundled_skill()
     if not source.is_file():
         raise FileNotFoundError(f"bundled skill not found at {source}")
-    text = source.read_text(encoding="utf-8")
+    content = source.read_bytes()
     written: list[Path] = []
     for dest in skill_destinations(home or Path.home()):
         if only_existing and not dest.is_file():
             continue
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(text, encoding="utf-8")
+        dest.write_bytes(content)
         written.append(dest)
     return written
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ def test_install_skill_writes_host_dirs(tmp_path):
     assert zcode.is_file()
     for dest in expected:
         assert dest.is_file()
-        assert dest.read_text(encoding="utf-8") == bundled_skill().read_text(encoding="utf-8")
+        assert dest.read_bytes() == bundled_skill().read_bytes()
 
 
 def test_install_skill_only_existing(tmp_path):
@@ -62,7 +62,7 @@ def test_install_skill_only_existing(tmp_path):
     dest.write_text("old", encoding="utf-8")
     written = install_skill(home=tmp_path, only_existing=True)
     assert written == [dest]
-    assert dest.read_text(encoding="utf-8") == bundled_skill().read_text(encoding="utf-8")
+    assert dest.read_bytes() == bundled_skill().read_bytes()
     assert not (tmp_path / ".codex" / "skills" / "agent-bridge" / "SKILL.md").exists()
 
 
@@ -85,7 +85,7 @@ def test_upgrade_uv_tool(monkeypatch, tmp_path):
 
     notes = upgrade(kind="uv-tool", siblings=0, run=fake_run)
     assert calls == [["/bin/uv", "tool", "upgrade", "agent-bridge"]]
-    assert dest.read_text(encoding="utf-8") == bundled_skill().read_text(encoding="utf-8")
+    assert dest.read_bytes() == bundled_skill().read_bytes()
     assert any("uv tool upgrade" in note for note in notes)
 
 


### PR DESCRIPTION
## 解决什么问题

安装或升级协调器 Skill 时，当前实现会先按文本读取，再重新写回。Windows 上这可能改变换行符，导致安装后的 SKILL.md 和内置文件内容、哈希不一致，给完整性检查和升级判断带来干扰。

## 怎么改

直接按字节复制文件，确保安装前后内容完全一致。

## 测试

- pytest tests/test_cli.py -q：13 项通过
- pytest -q：284 项通过